### PR TITLE
Cleaning up prefix paths, etc

### DIFF
--- a/templates/quickstart-aws-acm-certificate.template.yml
+++ b/templates/quickstart-aws-acm-certificate.template.yml
@@ -105,16 +105,14 @@ Resources:
     Properties:
       TemplateURL:
         !Sub
-          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${Path}'
-          - Path:  !If [IsSubmodule, !Sub "${QSS3KeyPrefix}submodules/quickstart-aws-acm-certificate/submodules/lambda-copyzips/templates/copy-zips.template.yaml", !Sub "${QSS3KeyPrefix}submodules/lambda-copyzips/templates/copy-zips.template.yaml"]
-            S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
+          - 'https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/lambda-copyzips/templates/copy-zips.template.yaml'
+          - S3Region: !If [UsingDefaultBucket, !Ref 'AWS::Region', !Ref QSS3BucketRegion]
             S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
-        #SourceObjects:  "functions/packages/ACMCert/lambda.zip"
-        SourceObjects: !If [IsSubmodule, !Sub "submodules/quickstart-aws-acm-certificate/functions/packages/ACMCert/lambda.zip", !Sub "functions/packages/ACMCert/lambda.zip"]
+        SourceObjects: "functions/packages/ACMCert/lambda.zip"
   ACMCertificateRole:
     Condition: SetupRoute53
     Type: AWS::IAM::Role
@@ -171,7 +169,7 @@ Resources:
       Timeout: 900
       Code:
         S3Bucket: !GetAtt "CopyZips.Outputs.LambdaZipsBucket"
-        S3Key: !If [ IsSubmodule, !Sub "${QSS3KeyPrefix}submodules/quickstart-aws-acm-certificate/functions/packages/ACMCert/lambda.zip" ,!Sub "${QSS3KeyPrefix}functions/packages/ACMCert/lambda.zip"]
+        S3Key: !Sub "${QSS3KeyPrefix}functions/packages/ACMCert/lambda.zip"
   ACMCertificateDNS:
     Condition: SetupRoute53
     Type: AWS::CloudFormation::CustomResource

--- a/templates/quickstart-aws-acm-certificate.template.yml
+++ b/templates/quickstart-aws-acm-certificate.template.yml
@@ -127,7 +127,7 @@ Resources:
             Service: lambda.amazonaws.com
           Action: sts:AssumeRole
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Path: "/"
       Policies:
       - PolicyName: lambda-acm
@@ -150,7 +150,7 @@ Resources:
             Action:
             - route53:ChangeResourceRecordSets
             Resource:
-            - Fn::Sub: arn:aws:route53:::hostedzone/${HostedZoneID}
+              - Fn::Sub: arn:${AWS::Partition}:route53:::hostedzone/${HostedZoneID}
           - Effect: Allow
             Action:
             - logs:FilterLogEvents


### PR DESCRIPTION
This PR solves a couple of sharp edges. 

- Conditionals existed to determine if the template was being used as a submodule. Using this as a submodule in a downstream QS caused a bunch of headache with these conditionals in. Keeping to the 'less-is-more' philosphy, the `QSS3KeyPrefix` parameter is passed-through without transformation or modification. 

- Leveraging CopyZIps appended the prefix to the objects. However CopyZips does that as well, internal to the lambda function. This caused the nested stack to fail and was time consuming to track down.

Additionally, I've changed a couple ARNs to leverage `${AWS::Partition}` to comply with our best-practice of being partition-agnostic.