### PR TITLE
Adding a safe default for the new IAMRole parameter

### DIFF
--- a/templates/quickstart-aws-acm-certificate.template.yml
+++ b/templates/quickstart-aws-acm-certificate.template.yml
@@ -86,6 +86,7 @@ Parameters:
     Description: ARN of a pre-deployed IAM Role with sufficient permissions for the lambda;
       see the ACMCertificateRole resource in this template for reference
     Type: String
+    Default: ''
   SubjectAlternativeNames:
     Description: 'Subject Alternative Names seperated by commas. Must be valid FQDNs'
     Type: CommaDelimitedList


### PR DESCRIPTION
*Description of changes:*
IamRoleArn needs to be blank by default to not break existing usage patterns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
