### PR TITLE
Update quickstart-aws-acm-certificate.template.yml

### DIFF
--- a/templates/quickstart-aws-acm-certificate.template.yml
+++ b/templates/quickstart-aws-acm-certificate.template.yml
@@ -26,6 +26,7 @@ Metadata:
         default: IAM
       Parameters:
       - IamRoleArn
+      - PermissionsBoundaryArn
     ParameterLabels:
       QSS3BucketName:
         default: Quick Start S3 bucket name
@@ -39,6 +40,8 @@ Metadata:
         default: Domain name
       IamRoleArn:
         default: ARN of a pre-deployed IAM Role
+      PermissionsBoundaryArn:
+        default: Will be attached to all created IAM Roles to satisfy security requirements
       SubjectAlternativeNames:
         default: Subject AlternativeNames
 Parameters:
@@ -86,6 +89,10 @@ Parameters:
   IamRoleArn:
     Description: ARN of a pre-deployed IAM Role with sufficient permissions for the lambda;
       see the ACMCertificateRole resource in this template for reference
+    Type: String
+    Default: ''
+  PermissionsBoundaryArn:
+    Description: Will be attached to all created IAM Roles to satisfy security requirements
     Type: String
     Default: ''
   SubjectAlternativeNames:
@@ -149,6 +156,7 @@ Resources:
         QSS3BucketName: !Ref QSS3BucketName
         QSS3KeyPrefix: !Ref QSS3KeyPrefix
         SourceObjects: "functions/packages/ACMCert/lambda.zip"
+        PermissionsBoundaryArn: !Ref PermissionsBoundaryArn
   ACMCertificateRole:
     Condition: StackProvidedIAM
     Type: AWS::IAM::Role

--- a/templates/quickstart-aws-acm-certificate.template.yml
+++ b/templates/quickstart-aws-acm-certificate.template.yml
@@ -136,6 +136,7 @@ Conditions:
   StackProvidedIAM:
     Fn::Not:
       - Condition: CustomerProvidedIAM
+  PermissionsBoundaryProvided: !Not [!Equals ["", !Ref PermissionsBoundaryArn]]
 Resources:
   # So we can copy the ACM lambda everywhere
   CopyZips:
@@ -161,6 +162,12 @@ Resources:
     Condition: StackProvidedIAM
     Type: AWS::IAM::Role
     Properties:
+      PermissionsBoundary:
+        !If [
+          PermissionsBoundaryProvided,
+          !Ref PermissionsBoundaryArn,
+          !Ref AWS::NoValue,
+        ]
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
added PermissionsBoundaryArn parameter

*Issue #, if available:*
PermissionsBoundaryArn will not be propagated to the CopyZips stack.

*Description of changes:*
Added PermissionsBoundaryArn parameter and propagated it to the CopyZips stack

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
